### PR TITLE
fixed docker compose bug [issue #7]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.8.14-slim-buster
 
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 RUN pip3 install --upgrade pip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,19 +8,9 @@ services:
     ports:
       - 5001:5001
     volumes:
-      - ./nllb_serve:/app/nllb_serve
-    entrypoint: [ "gunicorn" ]
-    command:
-      [
-        "nllb_serve.app:app",
-        "-b",
-        "0.0.0.0:5001",
-        "-k",
-        "gevent",
-        "-w",
-        "4",
-        "--threads",
-        "8",
-        "--timeout",
-        "6000"
-      ]
+      - ./:/app/
+    entrypoint: [
+      "python3",
+      "-m", "nllb_serve",
+      "-mi", "facebook/nllb-200-3.3B"
+    ]


### PR DESCRIPTION
docker compose was outputting an error every time I compile because of some minor issues and lack of C compiler in the container causing the error 

```
#0 128.1       configure: error: no acceptable C compiler found in $PATH
#0 128.1       See `config.log' for more details
#0 128.1       Traceback (most recent call last):
#0 128.1         File "/usr/local/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
#0 128.1           main()
#0 128.1         File "/usr/local/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
#0 128.1           json_out['return_val'] = hook(**hook_input['kwargs'])
#0 128.1         File "/usr/local/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 251, in build_wheel
#0 128.1           return _build_backend().build_wheel(wheel_directory, config_settings,
#0 128.1         File "/tmp/pip-build-env-fweekebe/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 434, in build_wheel
#0 128.1           return self._build_with_temp_dir(
```
---
Edit: Closes #7 