### PR TITLE
fix: incompatibility with newer transformers package (fixes #20)

### DIFF
--- a/nllb_serve/app.py
+++ b/nllb_serve/app.py
@@ -142,7 +142,7 @@ def attach_translate_route(
         inputs = {k:v.to(device) for k, v in inputs.items()}
 
         translated_tokens = model.generate(
-            **inputs, forced_bos_token_id=tokenizer.lang_code_to_id[tgt_lang],
+            **inputs, forced_bos_token_id=tokenizer.convert_tokens_to_ids(tgt_lang),
             max_length = max_length)
         output = tokenizer.batch_decode(translated_tokens, skip_special_tokens=True)
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers>=4.21
+transformers>=4.38
 Flask==3.0.2
 Werkzeug>=3.0.0
 torch>=1.12


### PR DESCRIPTION
Implements the fix proposed by @GOvEy1nw.

Also increases the minimum required version of transformers to ensure that we don't get the opposite issue (of people using older transformers version).

I considered supporting both the old and new transformers releases, but given the current transformers release is v4.46 and the minimum required version to fix this issue is v4.38, I think it's safe to support the newer releases only, as 4.38 is already quite old.

I did not edit the version, I let you do it.